### PR TITLE
[Feat] Return error on fetch

### DIFF
--- a/lazycache.go
+++ b/lazycache.go
@@ -30,7 +30,7 @@ func New(fetcher Fetcher, ttl time.Duration, size int) *LazyCache {
 	}
 }
 
-func (cache *LazyCache) Get(id string) (interface{}, bool) {
+func (cache *LazyCache) Get(id string) (interface{}, bool, error) {
 	cache.lock.RLock()
 	item, exists := cache.items[id]
 	if exists == false {
@@ -43,7 +43,7 @@ func (cache *LazyCache) Get(id string) (interface{}, bool) {
 	if time.Now().After(expires) {
 		go cache.Fetch(id)
 	}
-	return object, object != nil
+	return object, object != nil, nil
 }
 
 func (cache *LazyCache) Set(id string, object interface{}) {
@@ -58,11 +58,11 @@ func (cache *LazyCache) Set(id string, object interface{}) {
 	}
 }
 
-func (cache *LazyCache) Fetch(id string) (interface{}, bool) {
+func (cache *LazyCache) Fetch(id string) (interface{}, bool, error) {
 	object, err := cache.fetcher(id)
 	if err != nil {
-		return nil, false
+		return nil, false, err
 	}
 	cache.Set(id, object)
-	return object, object != nil
+	return object, object != nil, nil
 }

--- a/lazycache_test.go
+++ b/lazycache_test.go
@@ -1,128 +1,139 @@
 package lazycache
 
 import (
-  "time"
-  "errors"
-  "testing"
+	"errors"
+	"testing"
+	"time"
 )
 
+var errorFetch = errors.New("oops")
+
 func TestFetchesWhenNotCached(t *testing.T) {
-  count := 0
-  cache := New(countFetcher(&count), time.Second, 1)
-  cache.Get("Hi")
-  if count != 1 {
-    t.Errorf("expected %+v to equal 1", count)
-  }
+	count := 0
+	cache := New(countFetcher(&count), time.Second, 1)
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
 }
 
 func TestDoesNotFetchWhenCached(t *testing.T) {
-  count := 0
-  cache := New(countFetcher(&count), time.Second, 1)
-  cache.Get("Hi")
-  cache.Get("Hi")
-  if count != 1 {
-    t.Errorf("expected %+v to equal 1", count)
-  }
+	count := 0
+	cache := New(countFetcher(&count), time.Second, 1)
+	cache.Get("Hi")
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
 }
 
 func TestReturnsCachedAndFetchesLazilyAfterTtl(t *testing.T) {
-  count := 0
-  cache := New(countFetcher(&count), time.Microsecond, 1)
+	count := 0
+	cache := New(countFetcher(&count), time.Microsecond, 1)
 
-  cache.Get("Hi")
+	cache.Get("Hi")
 
-  // Second get, returns old value (1) and fetches on the background.
-  time.Sleep(5 * time.Microsecond)
-  v2, _ := cache.Get("Hi")
+	// Second get, returns old value (1) and fetches on the background.
+	time.Sleep(5 * time.Microsecond)
+	v2, _, _ := cache.Get("Hi")
 
-  if v2.(int) != 1 {
-    t.Errorf("expected %+v to equal 1", v2.(int))
-  }
+	if v2.(int) != 1 {
+		t.Errorf("expected %+v to equal 1", v2.(int))
+	}
 
-  time.Sleep(2 * time.Microsecond)
+	time.Sleep(2 * time.Microsecond)
 
-  if count != 2 {
-    t.Errorf("expected %+v to equal 2", count)
-  }
+	if count != 2 {
+		t.Errorf("expected %+v to equal 2", count)
+	}
 
-  v3, _ := cache.Get("Hi")
+	v3, _, _ := cache.Get("Hi")
 
-  if v3.(int) != 2 {
-    t.Errorf("expected %+v to equal 2", v3.(int))
-  }
+	if v3.(int) != 2 {
+		t.Errorf("expected %+v to equal 2", v3.(int))
+	}
 }
 
 func TestDoesNotFetchErrorsUntilExpire(t *testing.T) {
-  count := 0
-  cache := New(nilFetcher(&count), time.Second, 1)
-  cache.Get("Hi")
-  cache.Get("Hi")
-  if count != 1 {
-    t.Errorf("expected %+v to equal 1", count)
-  }
+	count := 0
+	cache := New(nilFetcher(&count), time.Second, 1)
+	cache.Get("Hi")
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
 }
 
 func TestFirstFetchOfNilSavesTheObject(t *testing.T) {
-  count := 0
-  cache := New(nilFetcher(&count), time.Minute, 1)
-  obj, exists := cache.Get("Hi") // flush it
-  if exists {
-    t.Errorf("item should not exist")
-  }
-  if obj != nil {
-    t.Errorf("item should be nil")
-  }
+	count := 0
+	cache := New(nilFetcher(&count), time.Minute, 1)
+	obj, exists, _ := cache.Get("Hi") // flush it
+	if exists {
+		t.Errorf("item should not exist")
+	}
+	if obj != nil {
+		t.Errorf("item should be nil")
+	}
 }
 
 func TestFetchingNilErasesExistingValue(t *testing.T) {
-  count := 0
-  cache := New(nilFetcher(&count), time.Minute, 1)
-  cache.items["Hi"] = &Item{object: 99, expires: time.Now().Add(-time.Minute),}
-  cache.Get("Hi") // flush it
-  time.Sleep(2 * time.Microsecond)
-  obj, exists := cache.Get("Hi")
-  if exists {
-    t.Errorf("item should not exist")
-  }
-  if obj != nil {
-    t.Errorf("item should be nil")
-  }
+	count := 0
+	cache := New(nilFetcher(&count), time.Minute, 1)
+	cache.items["Hi"] = &Item{object: 99, expires: time.Now().Add(-time.Minute)}
+	cache.Get("Hi") // flush it
+	time.Sleep(2 * time.Microsecond)
+	obj, exists, _ := cache.Get("Hi")
+	if exists {
+		t.Errorf("item should not exist")
+	}
+	if obj != nil {
+		t.Errorf("item should be nil")
+	}
 }
 
 func TestErrorOnFetchKeepsOldValue(t *testing.T) {
-  count := 0
-  cache := New(errorFetcher(&count), time.Microsecond, 1)
-  cache.items["paul"] = &Item{object: 99, expires: time.Now().Add(-time.Hour),}
-  v1, _ := cache.Get("paul")
-  if v1.(int) != 99 {
-    t.Errorf("expected %+v to equal 99", v1.(int))
-  }
+	count := 0
+	cache := New(errorFetcher(&count), time.Microsecond, 1)
+	cache.items["paul"] = &Item{object: 99, expires: time.Now().Add(-time.Hour)}
+	v1, _, _ := cache.Get("paul")
+	if v1.(int) != 99 {
+		t.Errorf("expected %+v to equal 99", v1.(int))
+	}
+}
+
+func TestErrorOnFirstLookup(t *testing.T) {
+	count := 0
+	cache := New(errorFetcher(&count), time.Microsecond, 1)
+	_, _, err := cache.Get("paul")
+	if err != errorFetch {
+		t.Errorf("expected %v to equal %v", err, errorFetch)
+	}
 }
 
 func countFetcher(count *int) Fetcher {
-  return func (id string) (interface{}, error) {
-    *count += 1
-    return *count, nil
-  }
+	return func(id string) (interface{}, error) {
+		*count += 1
+		return *count, nil
+	}
 }
 
 func nilFetcher(count *int) Fetcher {
-  return func (id string) (interface{}, error) {
-    *count += 1
-    return nil, nil
-  }
+	return func(id string) (interface{}, error) {
+		*count += 1
+		return nil, nil
+	}
 }
 
 func slowNilFetcher(count *int) Fetcher {
-  return func (id string) (interface{}, error) {
-    time.Sleep(10 * time.Microsecond)
-    *count += 1
-    return nil, nil
-  }
+	return func(id string) (interface{}, error) {
+		time.Sleep(10 * time.Microsecond)
+		*count += 1
+		return nil, nil
+	}
 }
 
 func errorFetcher(count *int) Fetcher {
-  return func (id string) (interface{}, error) {
-    return nil, errors.New("oops")
-  }
+	return func(id string) (interface{}, error) {
+		return nil, errorFetch
+	}
 }


### PR DESCRIPTION
Changes
1. Return error for `Fetch` so that proper error can be propagated to the user on cold cache
2. Run `gofmt`