### PR TITLE
[Feat] Group Cache

### DIFF
--- a/lazycache.go
+++ b/lazycache.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Fetcher func(id string) (interface{}, error)
+type GroupFetcher func() (*map[string]interface{}, error)
 
 type Item struct {
 	object  interface{}
@@ -16,32 +17,50 @@ type Item struct {
 }
 
 type LazyCache struct {
-	fetcher Fetcher
-	ttl     time.Duration
-	lock    sync.RWMutex
-	items   map[string]*Item
+	fetcher      Fetcher
+	groupFetcher GroupFetcher
+	ttl          time.Duration
+	lock         sync.RWMutex
+	items        map[string]*Item
 }
 
 func New(fetcher Fetcher, ttl time.Duration, size int) *LazyCache {
 	return &LazyCache{
-		ttl:     ttl,
-		fetcher: fetcher,
-		items:   make(map[string]*Item, size),
+		ttl:          ttl,
+		fetcher:      fetcher,
+		groupFetcher: nil,
+		items:        make(map[string]*Item, size),
+	}
+}
+
+func NewGroup(groupFetcher GroupFetcher, ttl time.Duration, size int) *LazyCache {
+	return &LazyCache{
+		ttl:          ttl,
+		fetcher:      nil,
+		groupFetcher: groupFetcher,
+		items:        make(map[string]*Item, size),
 	}
 }
 
 func (cache *LazyCache) Get(id string) (interface{}, bool) {
 	cache.lock.RLock()
 	item, exists := cache.items[id]
-	if exists == false {
+	if !exists {
 		cache.lock.RUnlock()
+		if cache.groupFetcher != nil {
+			return cache.groupFetch(id)
+		}
 		return cache.Fetch(id)
 	}
 	expires := item.expires
 	object := item.object
 	cache.lock.RUnlock()
 	if time.Now().After(expires) {
-		go cache.Fetch(id)
+		if cache.groupFetcher != nil {
+			go cache.groupFetch(id)
+		} else {
+			go cache.Fetch(id)
+		}
 	}
 	return object, object != nil
 }
@@ -65,4 +84,20 @@ func (cache *LazyCache) Fetch(id string) (interface{}, bool) {
 	}
 	cache.Set(id, object)
 	return object, object != nil
+}
+
+func (cache *LazyCache) groupFetch(id string) (interface{}, bool) {
+	objects, err := cache.groupFetcher()
+	if err != nil || objects == nil {
+		return nil, false
+	}
+
+	var res interface{}
+	for k, v := range *objects {
+		cache.Set(k, v)
+		if k == id {
+			res = v
+		}
+	}
+	return res, res != nil
 }

--- a/lazycache.go
+++ b/lazycache.go
@@ -42,6 +42,18 @@ func NewGroup(groupFetcher GroupFetcher, ttl time.Duration, size int) *LazyCache
 	}
 }
 
+func (cache *LazyCache) SwapGroup(groupFetcher GroupFetcher) *LazyCache {
+	cache.groupFetcher = groupFetcher
+	cache.fetcher = nil
+	return cache
+}
+
+func (cache *LazyCache) SwapSingle(fetcher Fetcher) *LazyCache {
+	cache.fetcher = fetcher
+	cache.groupFetcher = nil
+	return cache
+}
+
 func (cache *LazyCache) Get(id string) (interface{}, bool) {
 	cache.lock.RLock()
 	item, exists := cache.items[id]

--- a/lazycache.go
+++ b/lazycache.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Fetcher func(id string) (interface{}, error)
-type GroupFetcher func() (*map[string]interface{}, error)
+type GroupFetcher func() (map[string]interface{}, error)
 
 type Item struct {
 	object  interface{}
@@ -102,7 +102,7 @@ func (cache *LazyCache) groupFetch(id string) (interface{}, bool) {
 	}
 
 	var res interface{}
-	for k, v := range *objects {
+	for k, v := range objects {
 		cache.Set(k, v)
 		if k == id {
 			res = v

--- a/lazycache_test.go
+++ b/lazycache_test.go
@@ -35,34 +35,34 @@ func errorFetcher(count *int) Fetcher {
 }
 
 func groupStoreFetcher(count *int) GroupFetcher {
-	return func() (*map[string]interface{}, error) {
+	return func() (map[string]interface{}, error) {
 		group := map[string]interface{}{
 			"Hi":  *count,
 			"Bye": *count,
 		}
-		return &group, nil
+		return group, nil
 	}
 }
 
 func groupCountFetcher(count *int) GroupFetcher {
-	return func() (*map[string]interface{}, error) {
+	return func() (map[string]interface{}, error) {
 		*count += 1
 		group := map[string]interface{}{
 			"Hi": *count,
 		}
-		return &group, nil
+		return group, nil
 	}
 }
 
 func groupNilFetcher(count *int) GroupFetcher {
-	return func() (*map[string]interface{}, error) {
+	return func() (map[string]interface{}, error) {
 		*count += 1
 		return nil, nil
 	}
 }
 
 func groupErrorFetcher(count *int) GroupFetcher {
-	return func() (*map[string]interface{}, error) {
+	return func() (map[string]interface{}, error) {
 		return nil, errors.New("oops")
 	}
 }
@@ -285,7 +285,7 @@ func TestSwapGroupOnFetchUsesGroup(t *testing.T) {
 	}
 	cache = cache.SwapCache(countFetcher((&count)), groupCountFetcher(&groupCount))
 	cache.Get("Hi")
-	time.Sleep(10 * time.Microsecond)
+	time.Sleep(20 * time.Microsecond)
 
 	if count != 1 {
 		t.Errorf("expected %+v to equal 1", count)
@@ -300,8 +300,8 @@ func TestSwapSingleOnFetchKeepsOldValue(t *testing.T) {
 	groupCount := 0
 	cache := NewGroup(groupCountFetcher(&groupCount), countFetcher((&count)), time.Second, 1)
 	cache.Get("Hi")
-	if count != 1 {
-		t.Errorf("expected %+v to equal 1", count)
+	if groupCount != 1 {
+		t.Errorf("expected %+v to equal 1", groupCount)
 	}
 	cache = cache.SwapCache(countFetcher(&count), nil)
 	v2, exists := cache.Get("Hi")
@@ -324,7 +324,7 @@ func TestSwapSingleOnFetchUsesSingle(t *testing.T) {
 	}
 	cache = cache.SwapCache(countFetcher(&count), nil)
 	cache.Get("Hi")
-	time.Sleep(10 * time.Microsecond)
+	time.Sleep(20 * time.Microsecond)
 
 	if count != 1 {
 		t.Errorf("expected %+v to equal 1", count)

--- a/lazycache_test.go
+++ b/lazycache_test.go
@@ -1,257 +1,285 @@
 package lazycache
 
 import (
-  "time"
-  "errors"
-  "testing"
+	"errors"
+	"testing"
+	"time"
 )
 
 func TestFetchesWhenNotCached(t *testing.T) {
-  count := 0
-  cache := New(countFetcher(&count), time.Second, 1)
-  cache.Get("Hi")
-  if count != 1 {
-    t.Errorf("expected %+v to equal 1", count)
-  }
+	count := 0
+	cache := New(countFetcher(&count), time.Second, 1)
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
 }
 
 func TestDoesNotFetchWhenCached(t *testing.T) {
-  count := 0
-  cache := New(countFetcher(&count), time.Second, 1)
-  cache.Get("Hi")
-  cache.Get("Hi")
-  if count != 1 {
-    t.Errorf("expected %+v to equal 1", count)
-  }
+	count := 0
+	cache := New(countFetcher(&count), time.Second, 1)
+	cache.Get("Hi")
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
 }
 
 func TestReturnsCachedAndFetchesLazilyAfterTtl(t *testing.T) {
-  count := 0
-  cache := New(countFetcher(&count), time.Microsecond, 1)
+	count := 0
+	cache := New(countFetcher(&count), time.Microsecond, 1)
 
-  cache.Get("Hi")
+	cache.Get("Hi")
 
-  // Second get, returns old value (1) and fetches on the background.
-  time.Sleep(5 * time.Microsecond)
-  v2, _ := cache.Get("Hi")
+	// Second get, returns old value (1) and fetches on the background.
+	time.Sleep(5 * time.Microsecond)
+	v2, _ := cache.Get("Hi")
 
-  if v2.(int) != 1 {
-    t.Errorf("expected %+v to equal 1", v2.(int))
-  }
+	if v2.(int) != 1 {
+		t.Errorf("expected %+v to equal 1", v2.(int))
+	}
 
-  time.Sleep(2 * time.Microsecond)
+	time.Sleep(2 * time.Microsecond)
 
-  if count != 2 {
-    t.Errorf("expected %+v to equal 2", count)
-  }
+	if count != 2 {
+		t.Errorf("expected %+v to equal 2", count)
+	}
 
-  v3, _ := cache.Get("Hi")
+	v3, _ := cache.Get("Hi")
 
-  if v3.(int) != 2 {
-    t.Errorf("expected %+v to equal 2", v3.(int))
-  }
+	if v3.(int) != 2 {
+		t.Errorf("expected %+v to equal 2", v3.(int))
+	}
 }
 
 func TestDoesNotFetchErrorsUntilExpire(t *testing.T) {
-  count := 0
-  cache := New(nilFetcher(&count), time.Second, 1)
-  cache.Get("Hi")
-  cache.Get("Hi")
-  if count != 1 {
-    t.Errorf("expected %+v to equal 1", count)
-  }
+	count := 0
+	cache := New(nilFetcher(&count), time.Second, 1)
+	cache.Get("Hi")
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
 }
 
 func TestFirstFetchOfNilSavesTheObject(t *testing.T) {
-  count := 0
-  cache := New(nilFetcher(&count), time.Minute, 1)
-  obj, exists := cache.Get("Hi") // flush it
-  if exists {
-    t.Errorf("item should not exist")
-  }
-  if obj != nil {
-    t.Errorf("item should be nil")
-  }
+	count := 0
+	cache := New(nilFetcher(&count), time.Minute, 1)
+	obj, exists := cache.Get("Hi") // flush it
+	if exists {
+		t.Errorf("item should not exist")
+	}
+	if obj != nil {
+		t.Errorf("item should be nil")
+	}
 }
 
 func TestFetchingNilErasesExistingValue(t *testing.T) {
-  count := 0
-  cache := New(nilFetcher(&count), time.Minute, 1)
-  cache.items["Hi"] = &Item{object: 99, expires: time.Now().Add(-time.Minute),}
-  cache.Get("Hi") // flush it
-  time.Sleep(2 * time.Microsecond)
-  obj, exists := cache.Get("Hi")
-  if exists {
-    t.Errorf("item should not exist")
-  }
-  if obj != nil {
-    t.Errorf("item should be nil")
-  }
+	count := 0
+	cache := New(nilFetcher(&count), time.Minute, 1)
+	cache.items["Hi"] = &Item{object: 99, expires: time.Now().Add(-time.Minute)}
+	cache.Get("Hi") // flush it
+	time.Sleep(2 * time.Microsecond)
+	obj, exists := cache.Get("Hi")
+	if exists {
+		t.Errorf("item should not exist")
+	}
+	if obj != nil {
+		t.Errorf("item should be nil")
+	}
 }
 
 func TestErrorOnFetchKeepsOldValue(t *testing.T) {
-  count := 0
-  cache := New(errorFetcher(&count), time.Microsecond, 1)
-  cache.items["paul"] = &Item{object: 99, expires: time.Now().Add(-time.Hour),}
-  v1, _ := cache.Get("paul")
-  if v1.(int) != 99 {
-    t.Errorf("expected %+v to equal 99", v1.(int))
-  }
+	count := 0
+	cache := New(errorFetcher(&count), time.Microsecond, 1)
+	cache.items["paul"] = &Item{object: 99, expires: time.Now().Add(-time.Hour)}
+	v1, _ := cache.Get("paul")
+	if v1.(int) != 99 {
+		t.Errorf("expected %+v to equal 99", v1.(int))
+	}
 }
 
 func countFetcher(count *int) Fetcher {
-  return func (id string) (interface{}, error) {
-    *count += 1
-    return *count, nil
-  }
+	return func(id string) (interface{}, error) {
+		*count += 1
+		return *count, nil
+	}
 }
 
 func nilFetcher(count *int) Fetcher {
-  return func (id string) (interface{}, error) {
-    *count += 1
-    return nil, nil
-  }
+	return func(id string) (interface{}, error) {
+		*count += 1
+		return nil, nil
+	}
 }
 
 func slowNilFetcher(count *int) Fetcher {
-  return func (id string) (interface{}, error) {
-    time.Sleep(10 * time.Microsecond)
-    *count += 1
-    return nil, nil
-  }
+	return func(id string) (interface{}, error) {
+		time.Sleep(10 * time.Microsecond)
+		*count += 1
+		return nil, nil
+	}
 }
 
 func errorFetcher(count *int) Fetcher {
-  return func(id string) (interface{}, error) {
-    return nil, errors.New("oops")
-  }
+	return func(id string) (interface{}, error) {
+		return nil, errors.New("oops")
+	}
 }
 
 func TestGroupStoresMultipleValues(t *testing.T) {
-  count := 0
-  cache := NewGroup(groupStoreFetcher(&count), time.Second, 1)
-  res, _ := cache.Get("Hi")
-  if res != count {
-    t.Errorf("expected %+v to equal 1", count)
-  }
-  res, _ = cache.Get("Bye")
-  if res != count {
-    t.Errorf("expected %+v to equal 1", count)
-  }
+	count := 0
+	cache := NewGroup(groupStoreFetcher(&count), time.Second, 1)
+	res, _ := cache.Get("Hi")
+	if res != count {
+		t.Errorf("expected %+v to equal 1", count)
+	}
+	res, _ = cache.Get("Bye")
+	if res != count {
+		t.Errorf("expected %+v to equal 1", count)
+	}
 }
 
 func TestGroupFetchesWhenNotCached(t *testing.T) {
-  count := 0
-  cache := NewGroup(groupCountFetcher(&count), time.Second, 1)
-  cache.Get("Hi")
-  if count != 1 {
-    t.Errorf("expected %+v to equal 1", count)
-  }
+	count := 0
+	cache := NewGroup(groupCountFetcher(&count), time.Second, 1)
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
 }
 
 func TestGroupDoesNotFetchWhenCached(t *testing.T) {
-  count := 0
-  cache := NewGroup(groupCountFetcher(&count), time.Second, 1)
-  cache.Get("Hi")
-  cache.Get("Hi")
-  if count != 1 {
-    t.Errorf("expected %+v to equal 1", count)
-  }
+	count := 0
+	cache := NewGroup(groupCountFetcher(&count), time.Second, 1)
+	cache.Get("Hi")
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
 }
 
 func TestGroupReturnsCachedAndFetchesLazilyAfterTtl(t *testing.T) {
-  count := 0
-  cache := NewGroup(groupCountFetcher(&count), time.Microsecond, 1)
+	count := 0
+	cache := NewGroup(groupCountFetcher(&count), time.Microsecond, 1)
 
-  cache.Get("Hi")
+	cache.Get("Hi")
 
-  // Second get, returns old value (1) and fetches on the background.
-  time.Sleep(5 * time.Microsecond)
-  v2, _ := cache.Get("Hi")
+	// Second get, returns old value (1) and fetches on the background.
+	time.Sleep(5 * time.Microsecond)
+	v2, _ := cache.Get("Hi")
 
-  if v2.(int) != 1 {
-    t.Errorf("expected %+v to equal 1", v2.(int))
-  }
+	if v2.(int) != 1 {
+		t.Errorf("expected %+v to equal 1", v2.(int))
+	}
 
-  time.Sleep(2 * time.Microsecond)
+	time.Sleep(2 * time.Microsecond)
 
-  if count != 2 {
-    t.Errorf("expected %+v to equal 2", count)
-  }
+	if count != 2 {
+		t.Errorf("expected %+v to equal 2", count)
+	}
 
-  v3, _ := cache.Get("Hi")
+	v3, _ := cache.Get("Hi")
 
-  if v3.(int) != 2 {
-    t.Errorf("expected %+v to equal 2", v3.(int))
-  }
+	if v3.(int) != 2 {
+		t.Errorf("expected %+v to equal 2", v3.(int))
+	}
 }
 
 func TestGroupFirstFetchOfNilSavesTheObject(t *testing.T) {
-  count := 0
-  cache := NewGroup(groupNilFetcher(&count), time.Minute, 1)
-  obj, exists := cache.Get("Hi") // flush it
-  if exists {
-    t.Errorf("item should not exist")
-  }
-  if obj != nil {
-    t.Errorf("item should be nil")
-  }
+	count := 0
+	cache := NewGroup(groupNilFetcher(&count), time.Minute, 1)
+	obj, exists := cache.Get("Hi") // flush it
+	if exists {
+		t.Errorf("item should not exist")
+	}
+	if obj != nil {
+		t.Errorf("item should be nil")
+	}
 }
 
 func TestGroupFetchingNilDoesNotSave(t *testing.T) {
-  count := 0
-  cache := NewGroup(groupNilFetcher(&count), time.Minute, 1)
-  cache.items["Hi"] = &Item{object: 99, expires: time.Now().Add(-time.Minute)}
-  cache.Get("Hi") // flush it
-  time.Sleep(10 * time.Microsecond)
-  obj, exists := cache.Get("Hi")
-  if !exists {
-    t.Errorf("item should exist")
-  }
-  if obj == nil {
-    t.Errorf("item should not be nil")
-  }
+	count := 0
+	cache := NewGroup(groupNilFetcher(&count), time.Minute, 1)
+	cache.items["Hi"] = &Item{object: 99, expires: time.Now().Add(-time.Minute)}
+	cache.Get("Hi") // flush it
+	time.Sleep(10 * time.Microsecond)
+	obj, exists := cache.Get("Hi")
+	if !exists {
+		t.Errorf("item should exist")
+	}
+	if obj == nil {
+		t.Errorf("item should not be nil")
+	}
 }
 
 func TestGroupErrorOnFetchKeepsOldValue(t *testing.T) {
-  count := 0
-  cache := NewGroup(groupErrorFetcher(&count), time.Microsecond, 1)
-  cache.items["paul"] = &Item{object: 99, expires: time.Now().Add(-time.Hour)}
-  v1, _ := cache.Get("paul")
-  if v1.(int) != 99 {
-    t.Errorf("expected %+v to equal 99", v1.(int))
-  }
+	count := 0
+	cache := NewGroup(groupErrorFetcher(&count), time.Microsecond, 1)
+	cache.items["paul"] = &Item{object: 99, expires: time.Now().Add(-time.Hour)}
+	v1, _ := cache.Get("paul")
+	if v1.(int) != 99 {
+		t.Errorf("expected %+v to equal 99", v1.(int))
+	}
+}
+
+func TestSwapGroupOnFetchKeepsOldValue(t *testing.T) {
+	count := 0
+	cache := New(countFetcher(&count), time.Second, 1)
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
+	cache = cache.SwapGroup(groupCountFetcher(&count))
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
+}
+
+func TestSwapSingleOnFetchKeepsOldValue(t *testing.T) {
+	count := 0
+	cache := NewGroup(groupCountFetcher(&count), time.Second, 1)
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
+	cache = cache.SwapSingle(countFetcher(&count))
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
 }
 
 func groupStoreFetcher(count *int) GroupFetcher {
-  return func() (*map[string]interface{}, error) {
-    group := map[string]interface{}{
-      "Hi":  *count,
-      "Bye": *count,
-    }
-    return &group, nil
-  }
+	return func() (*map[string]interface{}, error) {
+		group := map[string]interface{}{
+			"Hi":  *count,
+			"Bye": *count,
+		}
+		return &group, nil
+	}
 }
 
 func groupCountFetcher(count *int) GroupFetcher {
-  return func() (*map[string]interface{}, error) {
-    *count += 1
-    group := map[string]interface{}{
-      "Hi": *count,
-    }
-    return &group, nil
-  }
+	return func() (*map[string]interface{}, error) {
+		*count += 1
+		group := map[string]interface{}{
+			"Hi": *count,
+		}
+		return &group, nil
+	}
 }
 
 func groupNilFetcher(count *int) GroupFetcher {
-  return func() (*map[string]interface{}, error) {
-    *count += 1
-    return nil, nil
-  }
+	return func() (*map[string]interface{}, error) {
+		*count += 1
+		return nil, nil
+	}
 }
 
 func groupErrorFetcher(count *int) GroupFetcher {
-  return func() (*map[string]interface{}, error) {
-    return nil, errors.New("oops")
-  }
+	return func() (*map[string]interface{}, error) {
+		return nil, errors.New("oops")
+	}
 }

--- a/lazycache_test.go
+++ b/lazycache_test.go
@@ -122,7 +122,136 @@ func slowNilFetcher(count *int) Fetcher {
 }
 
 func errorFetcher(count *int) Fetcher {
-  return func (id string) (interface{}, error) {
+  return func(id string) (interface{}, error) {
+    return nil, errors.New("oops")
+  }
+}
+
+func TestGroupStoresMultipleValues(t *testing.T) {
+  count := 0
+  cache := NewGroup(groupStoreFetcher(&count), time.Second, 1)
+  res, _ := cache.Get("Hi")
+  if res != count {
+    t.Errorf("expected %+v to equal 1", count)
+  }
+  res, _ = cache.Get("Bye")
+  if res != count {
+    t.Errorf("expected %+v to equal 1", count)
+  }
+}
+
+func TestGroupFetchesWhenNotCached(t *testing.T) {
+  count := 0
+  cache := NewGroup(groupCountFetcher(&count), time.Second, 1)
+  cache.Get("Hi")
+  if count != 1 {
+    t.Errorf("expected %+v to equal 1", count)
+  }
+}
+
+func TestGroupDoesNotFetchWhenCached(t *testing.T) {
+  count := 0
+  cache := NewGroup(groupCountFetcher(&count), time.Second, 1)
+  cache.Get("Hi")
+  cache.Get("Hi")
+  if count != 1 {
+    t.Errorf("expected %+v to equal 1", count)
+  }
+}
+
+func TestGroupReturnsCachedAndFetchesLazilyAfterTtl(t *testing.T) {
+  count := 0
+  cache := NewGroup(groupCountFetcher(&count), time.Microsecond, 1)
+
+  cache.Get("Hi")
+
+  // Second get, returns old value (1) and fetches on the background.
+  time.Sleep(5 * time.Microsecond)
+  v2, _ := cache.Get("Hi")
+
+  if v2.(int) != 1 {
+    t.Errorf("expected %+v to equal 1", v2.(int))
+  }
+
+  time.Sleep(2 * time.Microsecond)
+
+  if count != 2 {
+    t.Errorf("expected %+v to equal 2", count)
+  }
+
+  v3, _ := cache.Get("Hi")
+
+  if v3.(int) != 2 {
+    t.Errorf("expected %+v to equal 2", v3.(int))
+  }
+}
+
+func TestGroupFirstFetchOfNilSavesTheObject(t *testing.T) {
+  count := 0
+  cache := NewGroup(groupNilFetcher(&count), time.Minute, 1)
+  obj, exists := cache.Get("Hi") // flush it
+  if exists {
+    t.Errorf("item should not exist")
+  }
+  if obj != nil {
+    t.Errorf("item should be nil")
+  }
+}
+
+func TestGroupFetchingNilDoesNotSave(t *testing.T) {
+  count := 0
+  cache := NewGroup(groupNilFetcher(&count), time.Minute, 1)
+  cache.items["Hi"] = &Item{object: 99, expires: time.Now().Add(-time.Minute)}
+  cache.Get("Hi") // flush it
+  time.Sleep(10 * time.Microsecond)
+  obj, exists := cache.Get("Hi")
+  if !exists {
+    t.Errorf("item should exist")
+  }
+  if obj == nil {
+    t.Errorf("item should not be nil")
+  }
+}
+
+func TestGroupErrorOnFetchKeepsOldValue(t *testing.T) {
+  count := 0
+  cache := NewGroup(groupErrorFetcher(&count), time.Microsecond, 1)
+  cache.items["paul"] = &Item{object: 99, expires: time.Now().Add(-time.Hour)}
+  v1, _ := cache.Get("paul")
+  if v1.(int) != 99 {
+    t.Errorf("expected %+v to equal 99", v1.(int))
+  }
+}
+
+func groupStoreFetcher(count *int) GroupFetcher {
+  return func() (*map[string]interface{}, error) {
+    group := map[string]interface{}{
+      "Hi":  *count,
+      "Bye": *count,
+    }
+    return &group, nil
+  }
+}
+
+func groupCountFetcher(count *int) GroupFetcher {
+  return func() (*map[string]interface{}, error) {
+    *count += 1
+    group := map[string]interface{}{
+      "Hi": *count,
+    }
+    return &group, nil
+  }
+}
+
+func groupNilFetcher(count *int) GroupFetcher {
+  return func() (*map[string]interface{}, error) {
+    *count += 1
+    return nil, nil
+  }
+}
+
+func groupErrorFetcher(count *int) GroupFetcher {
+  return func() (*map[string]interface{}, error) {
     return nil, errors.New("oops")
   }
 }

--- a/lazycache_test.go
+++ b/lazycache_test.go
@@ -6,6 +6,67 @@ import (
 	"time"
 )
 
+func countFetcher(count *int) Fetcher {
+	return func(id string) (interface{}, error) {
+		*count += 1
+		return *count, nil
+	}
+}
+
+func nilFetcher(count *int) Fetcher {
+	return func(id string) (interface{}, error) {
+		*count += 1
+		return nil, nil
+	}
+}
+
+func slowNilFetcher(count *int) Fetcher {
+	return func(id string) (interface{}, error) {
+		time.Sleep(10 * time.Microsecond)
+		*count += 1
+		return nil, nil
+	}
+}
+
+func errorFetcher(count *int) Fetcher {
+	return func(id string) (interface{}, error) {
+		return nil, errors.New("oops")
+	}
+}
+
+func groupStoreFetcher(count *int) GroupFetcher {
+	return func() (*map[string]interface{}, error) {
+		group := map[string]interface{}{
+			"Hi":  *count,
+			"Bye": *count,
+		}
+		return &group, nil
+	}
+}
+
+func groupCountFetcher(count *int) GroupFetcher {
+	return func() (*map[string]interface{}, error) {
+		*count += 1
+		group := map[string]interface{}{
+			"Hi": *count,
+		}
+		return &group, nil
+	}
+}
+
+func groupNilFetcher(count *int) GroupFetcher {
+	return func() (*map[string]interface{}, error) {
+		*count += 1
+		return nil, nil
+	}
+}
+
+func groupErrorFetcher(count *int) GroupFetcher {
+	return func() (*map[string]interface{}, error) {
+		return nil, errors.New("oops")
+	}
+}
+
 func TestFetchesWhenNotCached(t *testing.T) {
 	count := 0
 	cache := New(countFetcher(&count), time.Second, 1)
@@ -79,7 +140,7 @@ func TestFetchingNilErasesExistingValue(t *testing.T) {
 	cache := New(nilFetcher(&count), time.Minute, 1)
 	cache.items["Hi"] = &Item{object: 99, expires: time.Now().Add(-time.Minute)}
 	cache.Get("Hi") // flush it
-	time.Sleep(2 * time.Microsecond)
+	time.Sleep(5 * time.Microsecond)
 	obj, exists := cache.Get("Hi")
 	if exists {
 		t.Errorf("item should not exist")
@@ -99,37 +160,9 @@ func TestErrorOnFetchKeepsOldValue(t *testing.T) {
 	}
 }
 
-func countFetcher(count *int) Fetcher {
-	return func(id string) (interface{}, error) {
-		*count += 1
-		return *count, nil
-	}
-}
-
-func nilFetcher(count *int) Fetcher {
-	return func(id string) (interface{}, error) {
-		*count += 1
-		return nil, nil
-	}
-}
-
-func slowNilFetcher(count *int) Fetcher {
-	return func(id string) (interface{}, error) {
-		time.Sleep(10 * time.Microsecond)
-		*count += 1
-		return nil, nil
-	}
-}
-
-func errorFetcher(count *int) Fetcher {
-	return func(id string) (interface{}, error) {
-		return nil, errors.New("oops")
-	}
-}
-
 func TestGroupStoresMultipleValues(t *testing.T) {
 	count := 0
-	cache := NewGroup(groupStoreFetcher(&count), time.Second, 1)
+	cache := NewGroup(groupStoreFetcher(&count), nil, time.Second, 1)
 	res, _ := cache.Get("Hi")
 	if res != count {
 		t.Errorf("expected %+v to equal 1", count)
@@ -142,7 +175,7 @@ func TestGroupStoresMultipleValues(t *testing.T) {
 
 func TestGroupFetchesWhenNotCached(t *testing.T) {
 	count := 0
-	cache := NewGroup(groupCountFetcher(&count), time.Second, 1)
+	cache := NewGroup(groupCountFetcher(&count), nil, time.Second, 1)
 	cache.Get("Hi")
 	if count != 1 {
 		t.Errorf("expected %+v to equal 1", count)
@@ -151,7 +184,7 @@ func TestGroupFetchesWhenNotCached(t *testing.T) {
 
 func TestGroupDoesNotFetchWhenCached(t *testing.T) {
 	count := 0
-	cache := NewGroup(groupCountFetcher(&count), time.Second, 1)
+	cache := NewGroup(groupCountFetcher(&count), nil, time.Second, 1)
 	cache.Get("Hi")
 	cache.Get("Hi")
 	if count != 1 {
@@ -161,7 +194,7 @@ func TestGroupDoesNotFetchWhenCached(t *testing.T) {
 
 func TestGroupReturnsCachedAndFetchesLazilyAfterTtl(t *testing.T) {
 	count := 0
-	cache := NewGroup(groupCountFetcher(&count), time.Microsecond, 1)
+	cache := NewGroup(groupCountFetcher(&count), nil, time.Microsecond, 1)
 
 	cache.Get("Hi")
 
@@ -186,9 +219,9 @@ func TestGroupReturnsCachedAndFetchesLazilyAfterTtl(t *testing.T) {
 	}
 }
 
-func TestGroupFirstFetchOfNilSavesTheObject(t *testing.T) {
+func TestGroupFirstFetchOfNilReturnsNil(t *testing.T) {
 	count := 0
-	cache := NewGroup(groupNilFetcher(&count), time.Minute, 1)
+	cache := NewGroup(groupNilFetcher(&count), nil, time.Minute, 1)
 	obj, exists := cache.Get("Hi") // flush it
 	if exists {
 		t.Errorf("item should not exist")
@@ -198,12 +231,12 @@ func TestGroupFirstFetchOfNilSavesTheObject(t *testing.T) {
 	}
 }
 
-func TestGroupFetchingNilDoesNotSave(t *testing.T) {
+func TestGroupFetchingNilDoesNotSaveObject(t *testing.T) {
 	count := 0
-	cache := NewGroup(groupNilFetcher(&count), time.Minute, 1)
+	cache := NewGroup(groupNilFetcher(&count), nil, time.Minute, 1)
 	cache.items["Hi"] = &Item{object: 99, expires: time.Now().Add(-time.Minute)}
 	cache.Get("Hi") // flush it
-	time.Sleep(10 * time.Microsecond)
+	time.Sleep(5 * time.Microsecond)
 	obj, exists := cache.Get("Hi")
 	if !exists {
 		t.Errorf("item should exist")
@@ -215,7 +248,7 @@ func TestGroupFetchingNilDoesNotSave(t *testing.T) {
 
 func TestGroupErrorOnFetchKeepsOldValue(t *testing.T) {
 	count := 0
-	cache := NewGroup(groupErrorFetcher(&count), time.Microsecond, 1)
+	cache := NewGroup(groupErrorFetcher(&count), nil, time.Microsecond, 1)
 	cache.items["paul"] = &Item{object: 99, expires: time.Now().Add(-time.Hour)}
 	v1, _ := cache.Get("paul")
 	if v1.(int) != 99 {
@@ -225,61 +258,143 @@ func TestGroupErrorOnFetchKeepsOldValue(t *testing.T) {
 
 func TestSwapGroupOnFetchKeepsOldValue(t *testing.T) {
 	count := 0
-	cache := New(countFetcher(&count), time.Second, 1)
+	groupCount := 0
+	cache := New(countFetcher(&count), time.Microsecond, 1)
 	cache.Get("Hi")
 	if count != 1 {
 		t.Errorf("expected %+v to equal 1", count)
 	}
-	cache = cache.SwapGroup(groupCountFetcher(&count))
+	cache = cache.SwapCache(countFetcher((&count)), groupCountFetcher(&groupCount))
+	v2, exists := cache.Get("Hi")
+
+	if !exists {
+		t.Errorf("item should exist")
+	}
+	if v2.(int) != 1 {
+		t.Errorf("expected %+v to equal 1", v2.(int))
+	}
+}
+
+func TestSwapGroupOnFetchUsesGroup(t *testing.T) {
+	count := 0
+	groupCount := 0
+	cache := New(countFetcher(&count), time.Microsecond, 1)
 	cache.Get("Hi")
 	if count != 1 {
 		t.Errorf("expected %+v to equal 1", count)
+	}
+	cache = cache.SwapCache(countFetcher((&count)), groupCountFetcher(&groupCount))
+	cache.Get("Hi")
+	time.Sleep(10 * time.Microsecond)
+
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
+	if groupCount != 1 {
+		t.Errorf("expected %+v to equal 1", groupCount)
 	}
 }
 
 func TestSwapSingleOnFetchKeepsOldValue(t *testing.T) {
 	count := 0
-	cache := NewGroup(groupCountFetcher(&count), time.Second, 1)
+	groupCount := 0
+	cache := NewGroup(groupCountFetcher(&groupCount), countFetcher((&count)), time.Second, 1)
 	cache.Get("Hi")
 	if count != 1 {
 		t.Errorf("expected %+v to equal 1", count)
 	}
-	cache = cache.SwapSingle(countFetcher(&count))
+	cache = cache.SwapCache(countFetcher(&count), nil)
+	v2, exists := cache.Get("Hi")
+
+	if !exists {
+		t.Errorf("item should exist")
+	}
+	if v2.(int) != 1 {
+		t.Errorf("expected %+v to equal 1", v2.(int))
+	}
+}
+
+func TestSwapSingleOnFetchUsesSingle(t *testing.T) {
+	count := 0
+	groupCount := 0
+	cache := NewGroup(groupCountFetcher(&groupCount), countFetcher((&count)), time.Microsecond, 1)
 	cache.Get("Hi")
+	if groupCount != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
+	cache = cache.SwapCache(countFetcher(&count), nil)
+	cache.Get("Hi")
+	time.Sleep(10 * time.Microsecond)
+
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
+	if groupCount != 1 {
+		t.Errorf("expected %+v to equal 1", groupCount)
+	}
+}
+
+func TestGroupFallbackSavesTheObject(t *testing.T) {
+	count := 0
+	groupCount := 0
+	cache := NewGroup(groupNilFetcher(&groupCount), countFetcher((&count)), time.Minute, 1)
+	obj, exists := cache.Get("Hi") // flush it
+	if !exists {
+		t.Errorf("item should exist")
+	}
+	if obj == nil {
+		t.Errorf("item should not be nil")
+	}
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
+	}
+	if groupCount != 1 {
+		t.Errorf("expected %+v to equal 1", groupCount)
+	}
+}
+
+func TestGroupFallbackErrorSavesTheObject(t *testing.T) {
+	count := 0
+	groupCount := 0
+	cache := NewGroup(groupErrorFetcher(&groupCount), countFetcher((&count)), time.Minute, 1)
+	obj, exists := cache.Get("Hi") // flush it
+	if !exists {
+		t.Errorf("item should exist")
+	}
+	if obj == nil {
+		t.Errorf("item should not be nil")
+	}
 	if count != 1 {
 		t.Errorf("expected %+v to equal 1", count)
 	}
 }
 
-func groupStoreFetcher(count *int) GroupFetcher {
-	return func() (*map[string]interface{}, error) {
-		group := map[string]interface{}{
-			"Hi":  *count,
-			"Bye": *count,
-		}
-		return &group, nil
+func TestGroupNilFallbackErasesExistingValue(t *testing.T) {
+	groupCount := 0
+	cache := NewGroup(groupNilFetcher(&groupCount), nil, time.Minute, 1)
+	cache.items["Hi"] = &Item{object: 99, expires: time.Now().Add(-time.Minute)}
+	cache.Get("Hi") // flush it
+	time.Sleep(10 * time.Microsecond)
+	obj, exists := cache.Get("Hi")
+	if !exists {
+		t.Errorf("item should not exist")
+	}
+	if obj == nil {
+		t.Errorf("item should be nil")
 	}
 }
 
-func groupCountFetcher(count *int) GroupFetcher {
-	return func() (*map[string]interface{}, error) {
-		*count += 1
-		group := map[string]interface{}{
-			"Hi": *count,
-		}
-		return &group, nil
+func TestGroupFallbackErrorOnFetchSetsNewValue(t *testing.T) {
+	count := 0
+	groupCount := 0
+	cache := NewGroup(groupErrorFetcher(&groupCount), countFetcher((&count)), time.Microsecond, 1)
+	cache.items["paul"] = &Item{object: 99, expires: time.Now().Add(-time.Hour)}
+	v1, _ := cache.Get("paul")
+	if v1.(int) != 99 {
+		t.Errorf("expected %+v to equal 99", v1.(int))
 	}
-}
-
-func groupNilFetcher(count *int) GroupFetcher {
-	return func() (*map[string]interface{}, error) {
-		*count += 1
-		return nil, nil
-	}
-}
-
-func groupErrorFetcher(count *int) GroupFetcher {
-	return func() (*map[string]interface{}, error) {
-		return nil, errors.New("oops")
+	cache.Get("Hi")
+	if count != 1 {
+		t.Errorf("expected %+v to equal 1", count)
 	}
 }


### PR DESCRIPTION
Related Task: https://rakuten-viki.atlassian.net/browse/CORE-210?atlOrigin=eyJpIjoiMGZjNTkxOWY0YWUxNGViNmI4ZDYyYTk2NDNiMjVkZjQiLCJwIjoiaiJ9

**Context**:
Lazycache is used in `Apiproxy`. In order to reduce the number of api calls to the `Appman API`, we need to handle retrieval of a objects of objects to cache rather than caching each object individually.

**Changes**:
Added new group cache function that stores multiple values to the cache at a time.
Input is in the form of `map[string]interface{}`

Also added fallback to single object retrieval fetcher (for Apiproxy to use its previous implementation as fallback)

**More Info**:
https://rakuten-viki.atlassian.net/wiki/spaces/VIKI/pages/690847755/Appman+Rewrite+-+Apiproxy+Integration